### PR TITLE
skip eigen-utils is bot2-vis is not found

### DIFF
--- a/eigen-utils/src/CMakeLists.txt
+++ b/eigen-utils/src/CMakeLists.txt
@@ -12,6 +12,12 @@ if(NOT BOT_LCMGL_FOUND)
     return()             
 endif()
 
+pkg_check_modules(BOT_VIS bot2-vis)
+if(NOT BOT_VIS_FOUND)
+    message("bot2-vis not found. not building eigen-utils")
+    return()
+endif()
+
 add_subdirectory(eigen-fftw)
 
 


### PR DESCRIPTION
There was already a check for bot2-lcmgl-client, this adds another
check for bot2-vis.  libbot now has support for lcmgl with vis
disabled, so this check is helpful.
