### PR TITLE
Add missing bot2-core library dependency

### DIFF
--- a/lcm-utils/src/CMakeLists.txt
+++ b/lcm-utils/src/CMakeLists.txt
@@ -3,7 +3,7 @@ pods_use_pkg_config_packages(lcm-utils-channel-changer lcm)
 pods_install_executables(lcm-utils-channel-changer)
 
 add_executable(lcm-utils-fix-event-time fix-event-time.cpp)
-pods_use_pkg_config_packages(lcm-utils-fix-event-time lcm)
+pods_use_pkg_config_packages(lcm-utils-fix-event-time lcm bot2-core)
 pods_install_executables(lcm-utils-fix-event-time)
 
 pods_install_headers(lcm_utils.hpp DESTINATION lcm_utils)


### PR DESCRIPTION
Compilation on a new system has shown that the bot2-core was missing from the pkg-config resulting in the compiler not finding the lcmtypes/bot_core.hpp header.
