### PR TITLE
Explicitly cast enum to be int

### DIFF
--- a/eigen-utils/src/eigen_rigidbody.hpp
+++ b/eigen-utils/src/eigen_rigidbody.hpp
@@ -83,7 +83,7 @@ protected:
 
 public:
   RigidBodyState() :
-      vec(Eigen::VectorXd::Zero(basic_num_states)), utime(0), quat(Eigen::Quaterniond::Identity())
+      vec(Eigen::VectorXd::Zero((int) basic_num_states)), utime(0), quat(Eigen::Quaterniond::Identity())
   {
 
   }
@@ -103,7 +103,7 @@ public:
   }
 
   RigidBodyState(const rigid_body_pose_t * pose) :
-      vec(basic_num_states), utime(pose->utime)
+      vec((int) basic_num_states), utime(pose->utime)
   {
     Eigen::Map<const Eigen::Vector3d> velocity_map(pose->vel);
     Eigen::Map<const Eigen::Vector3d> angular_velocity_map(pose->rotation_rate);
@@ -121,7 +121,7 @@ public:
   }
 
   RigidBodyState(const rigid_body::pose_t * pose) :
-      vec(basic_num_states), utime(pose->utime)
+      vec((int) basic_num_states), utime(pose->utime)
   {
     Eigen::Map<const Eigen::Vector3d> velocity_map(pose->vel);
     Eigen::Map<const Eigen::Vector3d> angular_velocity_map(pose->rotation_rate);


### PR DESCRIPTION
Issue: With the new 3.2.92 (3.3-beta) that is used in Drake, we are seeing compilation issues when gcc assumes that enum = 15 might be a double. Casting enum to be an int with C++11 does throw other issues, and this works.
