### PR TITLE
C++11 compiler complains isnan is ambiguous

### DIFF
--- a/eigen-utils/src/eigen_rigidbody.hpp
+++ b/eigen-utils/src/eigen_rigidbody.hpp
@@ -327,11 +327,11 @@ public:
   bool hasNan() const
   {
     for (int ii = 0; ii < vec.rows(); ii++) {
-      if (isnan(this->vec(ii)))
+      if (std::isnan(this->vec(ii)))
         return true;
     }
     for (int ii = 0; ii < 4; ii++) {
-      if (isnan(this->quat.coeffs()(ii)))
+      if (std::isnan(this->quat.coeffs()(ii)))
         return true;
     }
 


### PR DESCRIPTION
C++11 compiler complains isnan at line 330 and 334 is ambiguous. Corrected by explicitly tell the compiler we want to use std isnan.
